### PR TITLE
do not modify reqs for scikit-image >= 0.13.1

### DIFF
--- a/conda_build/index.py
+++ b/conda_build/index.py
@@ -549,6 +549,9 @@ def _patch_repodata(index, subdir):
 
     for fn, record in index.items():
         if record['name'] == 'scikit-image':
+            # do not modify requirements of 0.13.1+
+            if VersionOrder(record['version']) >= VersionOrder('0.13.1'):
+                continue
             try:
                 idx = record['depends'].index("networkx >=1.8")
             except ValueError:


### PR DESCRIPTION
Scikit-image 0.13.1 supports networkx 2.0.  No modification of the requirements
should do done for these packages when indexing.